### PR TITLE
Top bar shadowed, not show systems informations

### DIFF
--- a/lib/app/modules/expenses/presentation/expenses_list/expenses_list_page.dart
+++ b/lib/app/modules/expenses/presentation/expenses_list/expenses_list_page.dart
@@ -21,19 +21,19 @@ class ExpensesListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        appBar: AppBar(
-          title: _userInfoTitleWidget(),
-          actions: [
-            Visibility(
-                visible: FirebaseAuth.instance.currentUser != null,
-                child: IconButton(
-                    onPressed: controller.signOut,
-                    icon: const Icon(Icons.logout)))
-          ],
-        ),
-        body: Padding(
+    return Scaffold(
+      appBar: AppBar(
+        title: _userInfoTitleWidget(),
+        actions: [
+          Visibility(
+              visible: FirebaseAuth.instance.currentUser != null,
+              child: IconButton(
+                  onPressed: controller.signOut,
+                  icon: const Icon(Icons.logout)))
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Column(
             children: [
@@ -77,16 +77,16 @@ class ExpensesListPage extends StatelessWidget {
             ],
           ),
         ),
-        floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.add),
-            onPressed: () async {
-              final persisted =
-                  await Modular.to.pushNamed(AppRoutes.expenseRoute + AppRoutes.saveExpense);
-              if (persisted == true) {
-                controller.loadExpenses(controller.resumeModel.currentDate);
-              }
-            }),
       ),
+      floatingActionButton: FloatingActionButton(
+          child: const Icon(Icons.add),
+          onPressed: () async {
+            final persisted =
+                await Modular.to.pushNamed(AppRoutes.expenseRoute + AppRoutes.saveExpense);
+            if (persisted == true) {
+              controller.loadExpenses(controller.resumeModel.currentDate);
+            }
+          }),
     );
   }
 

--- a/lib/app/modules/expenses/presentation/payment_method/payment_methods_page.dart
+++ b/lib/app/modules/expenses/presentation/payment_method/payment_methods_page.dart
@@ -25,14 +25,14 @@ class _PaymentMethodsPageState extends State<PaymentMethodsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        appBar: AppBar(
-          scrolledUnderElevation: 0,
-          /* If "0", removes shadowing after any body scroll physics */
-          title: const Text('Gerenciar'),
-        ),
-        body: Padding(
+    return Scaffold(
+      appBar: AppBar(
+        scrolledUnderElevation: 0,
+        /* If "0", removes shadowing after any body scroll physics */
+        title: const Text('Gerenciar'),
+      ),
+      body: SafeArea(
+        child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/app/modules/expenses/presentation/save_expense/save_expense_page.dart
+++ b/lib/app/modules/expenses/presentation/save_expense/save_expense_page.dart
@@ -27,12 +27,12 @@ class _SaveExpensePageState extends State<SaveExpensePage> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(widget.controller.isEdit ? 'Editar' : 'Despesa'),
-        ),
-        body: SingleChildScrollView(
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.controller.isEdit ? 'Editar' : 'Despesa'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
           child: Column(
             children: [
               const SizedBox(height: 25),
@@ -164,11 +164,11 @@ class _SaveExpensePageState extends State<SaveExpensePage> {
             ],
           ),
         ),
-        floatingActionButton: FloatingActionButton.extended(
-          onPressed: widget.controller.saveExpense,
-          label: const Text('Salvar'),
-          icon: const Icon(Icons.done_rounded),
-        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: widget.controller.saveExpense,
+        label: const Text('Salvar'),
+        icon: const Icon(Icons.done_rounded),
       ),
     );
   }


### PR DESCRIPTION
The top bar was not showing system infos, like battery or time, because of it's dark, conflicting with system's theme. A SafeArea widget was not being used properly and fix its location solved the issue.